### PR TITLE
Removed all locking on stats updates and introduce 32-bit ARM packed bin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Make all
-        run: make all
+      - name: Make Release
+        run: make release
       - name: Upload release binaries
         uses: alexellis/upload-assets@0.3.0
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Go parameters
 GOCMD=GO111MODULE=on go
 GOBUILD=$(GOCMD) build
+GOBUILDRACE=$(GOCMD) build -race
 GOINSTALL=$(GOCMD) install
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
@@ -8,7 +9,7 @@ GOGET=$(GOCMD) get
 GOMOD=$(GOCMD) mod
 GOFMT=$(GOCMD) fmt
 DISTDIR = ./dist
-OS_ARCHs = "linux/amd64 linux/arm64 windows/amd64 darwin/amd64 darwin/arm64"
+OS_ARCHs = "linux/amd64 linux/arm64 linux/arm windows/amd64 darwin/amd64 darwin/arm64"
 
 # Build-time GIT variables
 ifeq ($(GIT_SHA),)
@@ -20,11 +21,15 @@ GIT_DIRTY:=$(shell git diff --no-ext-diff 2> /dev/null | wc -l)
 endif
 
 .PHONY: all test coverage
-all: test build release
+all: test build
 
 build:
 	$(GOBUILD) \
 	-ldflags="-X 'main.GitSHA1=$(GIT_SHA)' -X 'main.GitDirty=$(GIT_DIRTY)'" .
+
+build-race:
+	$(GOBUILDRACE) \
+                   	-ldflags="-X 'main.GitSHA1=$(GIT_SHA)' -X 'main.GitDirty=$(GIT_DIRTY)'" .
 
 checkfmt:
 	@echo 'Checking gofmt';\

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ If you don't have go on your machine and just want to use the produced binaries 
 
 | OS | Arch | Link |
 | :---         |     :---:      |          ---: |
-| Windows   | amd64     | [redis-benchmark-go_windows_amd64.exe](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_windows_amd64.exe)    |
-| Linux   | amd64     | [redis-benchmark-go_linux_amd64](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_linux_amd64)    |
-| Linux   | arm64     | [redis-benchmark-go_linux_arm64](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_linux_arm64)    |
-| Darwin   | amd64     | [redis-benchmark-go_darwin_amd64](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_darwin_amd64)    |
-| Darwin   | arm64     | [redis-benchmark-go_darwin_arm64](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_darwin_arm64)    |
+| Windows   | amd64  (64-bit X86)     | [redis-benchmark-go_windows_amd64.exe](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_windows_amd64.exe)    |
+| Linux   | amd64  (64-bit X86)     | [redis-benchmark-go_linux_amd64](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_linux_amd64)    |
+| Linux   | arm64 (64-bit ARM)     | [redis-benchmark-go_linux_arm64](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_linux_arm64)    |
+| Linux   | arm (32-bit ARM)    | [redis-benchmark-go_linux_arm](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_linux_arm)    |
+| Darwin   | amd64  (64-bit X86)     | [redis-benchmark-go_darwin_amd64](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_darwin_amd64)    |
+| Darwin   | arm64 (64-bit ARM)     | [redis-benchmark-go_darwin_arm64](https://s3.amazonaws.com/benchmarks.redislabs/tools/redis-benchmark-go/redis-benchmark-go_darwin_arm64)    |
 
 
 


### PR DESCRIPTION
This PR fixes #9 and removes all locking from the benchmark tool. 


**Removed all locking on stats updates**
previous:
```
$ ./redis-benchmark-go -n 5000000 -c 50 -p 6379 set foo bar
Total clients: 50. Commands per client: 100000 Total commands: 5000000
Using random seed: 12345
                 Test time                    Total Commands              Total Errors                      Command Rate           p50 lat. (msec)
                       31s [100.0%]                   5000000                         0 [0.0%]                 159678.24                      0.30      
#################################################
Total Duration 31.000 Seconds
Total Errors 0
Throughput summary: 161288 requests per second
Latency summary (msec):
          p50       p95       p99
        0.299     0.428     0.626
```

current:
```
$ ./redis-benchmark-go -n 5000000 -c 50 -p 6379 set foo bar
Total clients: 50. Commands per client: 100000 Total commands: 5000000
Using random seed: 12345
                 Test time                    Total Commands              Total Errors                      Command Rate           p50 lat. (msec)
                       29s [100.0%]                   5000000                         0 [0.0%]                 106459.77                      0.29      
#################################################
Total Duration 29.001 Seconds
Total Errors 0
Throughput summary: 172407 requests per second
Latency summary (msec):
          p50       p95       p99
        0.287     0.369     0.564
```